### PR TITLE
使用中文全角括号，导致openFileDialog中的filter无法正常工作。中文全角括号改为英文括号。

### DIFF
--- a/assistant_zh_CN.4.5.0.ts
+++ b/assistant_zh_CN.4.5.0.ts
@@ -1039,7 +1039,7 @@ Reason:
     <message>
         <location filename="preferencesdialog.cpp" line="328"/>
         <source>Qt Compressed Help Files (*.qch)</source>
-        <translation>Qt压缩帮助文件（*.qch）</translation>
+        <translation>Qt压缩帮助文件 (*.qch)</translation>
     </message>
     <message>
         <location filename="preferencesdialog.cpp" line="360"/>

--- a/qtcreator_zh_CN.4.5.0.ts
+++ b/qtcreator_zh_CN.4.5.0.ts
@@ -25351,7 +25351,7 @@ Leave empty to search through the file system.</source>
     <message>
         <location line="+0"/>
         <source>Qt Help Files (*.qch)</source>
-        <translation>Qt帮助文件（*.qch）</translation>
+        <translation>Qt帮助文件 (*.qch)</translation>
     </message>
     <message>
         <location line="+44"/>


### PR DESCRIPTION
使用中文全角括号，导致assistant中注册文档时openFileDialog中的filter无法正常工作。
中文全角括号改为英文括号后，修正

qt版本：5.9.5，
qtCreator 版本：4.6.0
编译环境：MinGW-i686-5.3.0-release-posix-dwarf-rt_v4-rev0 , Win10 x64